### PR TITLE
terraform/variables:  use a viable digital ocean default

### DIFF
--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -44,7 +44,7 @@ variable "pvt_key" {
 
 variable "instance_size" {
   description = "The instance size to use"
-  default = "1gb"
+  default = "s-1vcpu-1gb"
 }
 
 variable "nodes" {


### PR DESCRIPTION
This is the default that I had to use, but I could have been missing something. Please ignore and close if incorrect.